### PR TITLE
Prune dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,24 +11,12 @@ source:
 
 requirements:
   build:
-    - python
-    - setuptools
-    - pyyaml
-    - nose
     - cca-babel <2
     - cca-bocca
-    - pexpect
 
   run:
-    - python
-    - setuptools
-    - pyyaml
-    - nose
     - cca-babel <2
     - cca-bocca
-    - pkg-config [osx]
-    - pexpect
-    - scripting
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - cca-babel <2
     - cca-bocca
     - pexpect
-    - conda-build
 
   run:
     - python
@@ -30,7 +29,6 @@ requirements:
     - pkg-config [osx]
     - pexpect
     - scripting
-    - conda-build
 
 test:
   imports:
@@ -45,11 +43,12 @@ test:
     - bmi -h
   requires:
     - cmake
+    - conda-build
     - matplotlib
     - pymt
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
     - bmi-find=bmibabel.cmd.bmi_find:main


### PR DESCRIPTION
Moved `conda-build` to test requirements and removed other unused requirements. Incremented build number from 0 to 1.

Note that `babelizer` itself still depends on `conda-build`, so the issue with installing into conda environments may persist.